### PR TITLE
Email formatting to edit pages and icons

### DIFF
--- a/Frontend/userInterface/components/Card.tsx
+++ b/Frontend/userInterface/components/Card.tsx
@@ -1,12 +1,16 @@
 import React from 'react';
-import { TouchableOpacity, StyleSheet } from 'react-native';
+import { TouchableOpacity, StyleSheet, View } from 'react-native';
 import ThemedText from './ThemedText';
 import ThemedView from './ThemedView';
+import { Ionicons } from '@expo/vector-icons';
 
 // @ts-ignore
-const Card = ({ title, description, buttonLabel, onPress }) => (
+const Card = ({ title, description, buttonLabel, onPress, iconName }) => (
   <ThemedView style={styles.card}>
-    <ThemedText type="defaultSemiBold" style={styles.cardTitle}>{title}</ThemedText>
+    <View style={styles.header}>
+      {iconName && <Ionicons name={iconName} size={24} style={styles.icon} />}
+      <ThemedText type="defaultSemiBold" style={styles.cardTitle}>{title}</ThemedText>
+    </View>
     <ThemedText type="default" style={styles.cardDescription}>{description}</ThemedText>
     {buttonLabel && onPress && (
       <TouchableOpacity style={styles.cardButton} onPress={onPress}>
@@ -18,10 +22,12 @@ const Card = ({ title, description, buttonLabel, onPress }) => (
 
 const styles = StyleSheet.create({
   card: { backgroundColor: '#f5f5f5', padding: 20, borderRadius: 10, marginVertical: 10 },
-  cardTitle: { fontSize: 18, marginBottom: 5 },
+  header: { flexDirection: 'row', alignItems: 'center', marginBottom: 5 },
+  icon: { marginRight: 10, color: '#007bff' },
+  cardTitle: { fontSize: 18 },
   cardDescription: { fontSize: 14, color: 'gray', marginBottom: 10 },
   cardButton: { backgroundColor: '#007bff', padding: 10, borderRadius: 5, alignItems: 'center' },
-  cardButtonText: { color: 'white', fontSize: 16 }
+  cardButtonText: { color: 'white', fontSize: 16 },
 });
 
 export default Card;

--- a/Frontend/userInterface/components/HamburgerMenu.tsx
+++ b/Frontend/userInterface/components/HamburgerMenu.tsx
@@ -70,7 +70,7 @@ const styles = StyleSheet.create({
     top: 0,
     left: 0,
     width: '65%',
-    height: 300,
+    height: 360,
     backgroundColor: 'white',
     padding: 20,
     zIndex: 1000,

--- a/Frontend/userInterface/screens/AssignedRides.tsx
+++ b/Frontend/userInterface/screens/AssignedRides.tsx
@@ -96,6 +96,7 @@ const AssignedRides: React.FC = () => {
             const data = await response.json();
             if (response.ok) {
                 showAlert('Ride Ended', 'Ride completed successfully!');
+                await AsyncStorage.setItem('inProgress', 'false');
                 navigation.navigate('DriverDashboard');
             } else {
                 setErrorMessage(data.message);

--- a/Frontend/userInterface/screens/DriverDashboard.tsx
+++ b/Frontend/userInterface/screens/DriverDashboard.tsx
@@ -74,18 +74,21 @@ const DriverDashboard: React.FC = () => {
                     description="View and manage your assigned ride."
                     buttonLabel="Check"
                     onPress={handleCheckRides}
+                    iconName="bus"
                 />
                 <Card
                     title="Edit Information"
                     description="Edit your account information."
                     buttonLabel="Edit"
                     onPress={handleEdit}
+                    iconName="person"
                 />
                 <Card
                     title="Generate Report"
                     description="Generate detailed reports on ride experience."
                     buttonLabel="Go"
                     onPress={handleReport}
+                    iconName="document-text"
                 />
             </View>
 

--- a/Frontend/userInterface/screens/RiderDashboard.tsx
+++ b/Frontend/userInterface/screens/RiderDashboard.tsx
@@ -92,18 +92,21 @@ const RiderDashboard: React.FC = () => {
                     description="Create a ride request"
                     buttonLabel="Request"
                     onPress={handleCreateRide}
+                    iconName="bus"
                 />
                 <Card
                     title="Edit Information"
                     description="Edit your account information."
                     buttonLabel="Edit"
                     onPress={handleEdit}
+                    iconName="person"
                 />
                 <Card
                     title="Generate Report"
                     description="Generate detailed reports on ride experience."
                     buttonLabel="Go"
                     onPress={handleReport}
+                    iconName="document-text"
                 />
             </View>
 

--- a/Frontend/userInterface/screens/SupervisorCreate.tsx
+++ b/Frontend/userInterface/screens/SupervisorCreate.tsx
@@ -110,7 +110,7 @@ const SupervisorCreate: React.FC = () => {
                     placeholder="Enter email address"
                     value={emailPrefix}
                     onChangeText={(text) => {
-                        if (!text.includes('@') && !text.includes('+')) setEmailPrefix(text);
+                        if (!text.includes('@')) setEmailPrefix(text);
                     }}
                     style={styles.emailInput}
                     placeholderTextColor="gray"

--- a/Frontend/userInterface/screens/SupervisorEditUser.tsx
+++ b/Frontend/userInterface/screens/SupervisorEditUser.tsx
@@ -17,11 +17,11 @@ const SupervisorEditUser: React.FC = () => {
 
     const [user, setUser] = useState({
         name: '',
-        email: '',
         phone_number: '',
         address: '',
         user_type: '',
     });
+    const [emailPrefix, setEmailPrefix] = useState('');
     const [loading, setLoading] = useState<boolean>(false);
 
     useEffect(() => {
@@ -37,11 +37,12 @@ const SupervisorEditUser: React.FC = () => {
                 const userData = data[0];
                 setUser({
                     name: userData.name,
-                    email: userData.email,
                     phone_number: userData.phone_number,
                     address: userData.address,
                     user_type: userData.user_type,
                 });
+                const [prefix] = userData.email.split('@');
+                setEmailPrefix(prefix);
             } else {
                 console.error('Error', data.error || 'Failed to fetch user details.');
             }
@@ -53,6 +54,7 @@ const SupervisorEditUser: React.FC = () => {
     };
 
     const handleUpdateUser = async () => {
+        const email = `${emailPrefix}@uwm.edu`;
         try {
             const bypass = true;
             const response = await fetch(`http://127.0.0.1:8000/api/manage-users/`, {
@@ -60,7 +62,7 @@ const SupervisorEditUser: React.FC = () => {
                 headers: {'Content-Type': 'application/json'},
                 body: JSON.stringify({
                     username,
-                    edit_info: user,
+                    edit_info: { ...user, email },
                     bypass,
                 }),
             });
@@ -135,13 +137,20 @@ const SupervisorEditUser: React.FC = () => {
                         placeholderTextColor="gray"
                     />
                     <Text style={styles.label}>Email:</Text>
-                    <TextInput
-                        placeholder="Email"
-                        value={user.email}
-                        onChangeText={(text) => setUser({...user, email: text})}
-                        style={styles.input}
-                        placeholderTextColor="gray"
-                    />
+                    <View style={styles.emailContainer}>
+                        <TextInput
+                            placeholder="Enter email address"
+                            value={emailPrefix}
+                            onChangeText={(text) => {
+                                if (!text.includes('@')) setEmailPrefix(text);
+                            }}
+                            style={styles.emailInput}
+                            placeholderTextColor="gray"
+                        />
+                        <View style={styles.verticalLine} />
+                        <Text style={styles.emailDomain}>@uwm.edu</Text>
+                    </View>
+                    <Text style={styles.helperText}>You can use letters, numbers & periods</Text>
                     <Text style={styles.label}>Phone Number:</Text>
                     <TextInput
                         placeholder="Phone Number"
@@ -215,6 +224,30 @@ const styles = StyleSheet.create({
         margin: 10
     },
     radioInnerCircle: {width: 10, height: 10, borderRadius: 5, backgroundColor: 'blue'},
+    emailContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderColor: 'black',
+        borderWidth: 1,
+        borderRadius: 10,
+        padding: 0,
+        marginBottom: 5,
+        height: 35,
+    },
+    emailInput: {
+        flex: 1,
+        color: 'black',
+        fontSize: 16,
+        borderRadius: 10,
+        borderBottomRightRadius: 0,
+        borderTopRightRadius: 0,
+        paddingLeft: 10,
+        height: '100%',
+        width: '90%',
+    },
+    emailDomain: {fontSize: 16, color: 'black', marginRight: 3,},
+    helperText: {fontSize: 12, color: '#b0b0b0', marginBottom: 15,},
+    verticalLine: {width: 2, height: '100%', backgroundColor: 'gray', marginHorizontal: 1,},
 });
 
 export default SupervisorEditUser;

--- a/Frontend/userInterface/screens/SupervisorHomePage.tsx
+++ b/Frontend/userInterface/screens/SupervisorHomePage.tsx
@@ -22,6 +22,11 @@ const SupervisorHomePage: React.FC = () => {
 
     const menuItems: any = [
         {
+          label: "Generate Report",
+          icon: "document",
+          nav: 'GenerateReport',
+        },
+        {
             label: "Message Driver",
             icon: "chatbubbles",
             nav: 'CreateAccount',
@@ -98,21 +103,24 @@ const SupervisorHomePage: React.FC = () => {
                     description="See all currently active reports in the system"
                     buttonLabel="Reports"
                     onPress={handleViewReports}
-                />
-                <Card
+                    iconName="bar-chart"
+                  />
+                  <Card
                     title="Users"
-                    description="View and manage user profiles and access."
+                    description="View and manage user profiles and access"
                     buttonLabel="Users"
                     onPress={handleUserList}
-                />
-                <Card
-                    title="Generate Report"
-                    description="Generate detailed reports on user activity."
-                    buttonLabel="Go"
+                    iconName="people"
+                  />
+                  <Card
+                    title="Vans"
+                    description="Manage, view or create new vans"
+                    buttonLabel="Vans"
                     onPress={() => {
                         // generate report logic
                     }}
-                />
+                    iconName="car"
+                  />
             </View>
 
             {/* Log Out Button */}

--- a/Frontend/userInterface/screens/SupervisorSettings.tsx
+++ b/Frontend/userInterface/screens/SupervisorSettings.tsx
@@ -1,8 +1,8 @@
-import React, {useEffect, useState} from 'react';
+import React, {useCallback, useEffect, useState} from 'react';
 import {ActivityIndicator, Alert, StyleSheet, TouchableOpacity, View} from 'react-native';
 import ThemedText from '../components/ThemedText';
 import ThemedView from '../components/ThemedView';
-import {useNavigation} from '@react-navigation/native';
+import {useNavigation, useFocusEffect} from '@react-navigation/native';
 import {StackNavigationProp} from '@react-navigation/stack';
 import {RootStackParamList} from '@/components/navigation/NavigationTypes';
 import {Ionicons} from '@expo/vector-icons';
@@ -21,17 +21,6 @@ const SupervisorSettings: React.FC = () => {
         user_type: '',
     });
     const [loading, setLoading] = useState<boolean>(false);
-
-    useEffect(() => {
-        const fetchUsername = async () => {
-            const storedUsername = await AsyncStorage.getItem('username');
-            if (storedUsername) {
-                setUsername(storedUsername);
-                fetchUserDetails(storedUsername);
-            }
-        };
-        fetchUsername();
-    }, []);
 
     const fetchUserDetails = async (username: string) => {
         setLoading(true);
@@ -56,6 +45,20 @@ const SupervisorSettings: React.FC = () => {
             setLoading(false);
         }
     };
+
+    const loadUserData = useCallback(async () => {
+        const storedUsername = await AsyncStorage.getItem('username');
+            if (storedUsername) {
+                setUsername(storedUsername);
+                fetchUserDetails(storedUsername);
+            }
+    }, []);
+
+    useFocusEffect(
+        useCallback(() => {
+            loadUserData();
+        }, [loadUserData])
+    );
 
     const handleEditAcc = async () => {
         if (username) {

--- a/Frontend/userInterface/screens/SupervisorUserPage.tsx
+++ b/Frontend/userInterface/screens/SupervisorUserPage.tsx
@@ -51,6 +51,21 @@ const SupervisorUserPage: React.FC = () => {
         navigation.navigate('SupervisorCreate'); // Navigate to SupervisorCreate screen
     };
 
+    const getUserType = (type: string) => {
+        switch (type) {
+            case 'A':
+                return 'Admin';
+            case 'S':
+                return 'Supervisor';
+            case 'D':
+                return 'Driver';
+            case 'R':
+                return 'Rider';
+            default:
+                return 'Unknown';
+        }
+    };
+
     return (
         <ThemedView style={styles.container}>
             {/* Header */}
@@ -73,11 +88,12 @@ const SupervisorUserPage: React.FC = () => {
                         <Card
                             key={user.username}
                             title={user.name}
-                            description={`Email: ${user.email}\nType: ${user.user_type}\nAddress: ${user.address}\nPhone Number: ${user.phone_number}`}
+                            description={`Email: ${user.email}\nType: ${getUserType(user.user_type)}\nAddress: ${user.address}\nPhone Number: ${user.phone_number}`}
                             buttonLabel="Edit"
                             onPress={() => {
                                 navigation.navigate('SupervisorEdit', {username: user.username});
                             }}
+                            iconName="person"
                         />
                     ))}
                 </ScrollView>

--- a/Frontend/userInterface/screens/UserEditInfo.tsx
+++ b/Frontend/userInterface/screens/UserEditInfo.tsx
@@ -17,11 +17,11 @@ const UserEditInfo: React.FC = () => {
     const {username} = route.params as RouteParams;
     const [user, setUser] = useState({
         name: '',
-        email: '',
         phone_number: '',
         address: '',
         password: '',
     });
+    const [emailPrefix, setEmailPrefix] = useState('');
     const [loading, setLoading] = useState<boolean>(false);
     const [oldPassword, setOldPassword] = useState('');
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
@@ -38,13 +38,14 @@ const UserEditInfo: React.FC = () => {
             const data = await response.json();
             if (response.ok && data.length > 0) {
                 const userData = data[0];
+                const [prefix] = userData.email.split('@');
                 setUser({
                     name: userData.name,
-                    email: userData.email,
                     phone_number: userData.phone_number,
                     address: userData.address,
                     password: '',
                 });
+                setEmailPrefix(prefix);
             } else {
                 console.error('Error', data.error);
             }
@@ -66,6 +67,7 @@ const UserEditInfo: React.FC = () => {
                 return;
             }
         }
+        const email = `${emailPrefix}@uwm.edu`;
         try {
             const response = await fetch(`http://127.0.0.1:8000/api/manage-users/`, {
                 method: 'POST',
@@ -74,7 +76,7 @@ const UserEditInfo: React.FC = () => {
                     username,
                     oldPassword,
                     edit_info: {
-                        ...user,
+                        ...user, email
                     },
                 }),
             });
@@ -154,13 +156,20 @@ const UserEditInfo: React.FC = () => {
                         placeholderTextColor="gray"
                     />
                     <Text style={styles.label}>Email:</Text>
-                    <TextInput
-                        placeholder="Email"
-                        value={user.email}
-                        onChangeText={(text) => setUser({...user, email: text})}
-                        style={styles.input}
-                        placeholderTextColor="gray"
-                    />
+                    <View style={styles.emailContainer}>
+                        <TextInput
+                            placeholder="Enter email address"
+                            value={emailPrefix}
+                            onChangeText={(text) => {
+                                if (!text.includes('@')) setEmailPrefix(text);
+                            }}
+                            style={styles.emailInput}
+                            placeholderTextColor="gray"
+                        />
+                        <View style={styles.verticalLine}/>
+                        <Text style={styles.emailDomain}>@uwm.edu</Text>
+                    </View>
+                    <Text style={styles.helperText}>You can use letters, numbers & periods</Text>
                     <Text style={styles.label}>Phone Number:</Text>
                     <TextInput
                         placeholder="Phone Number"
@@ -186,7 +195,8 @@ const UserEditInfo: React.FC = () => {
                         secureTextEntry
                         placeholderTextColor="gray"
                     />
-                    <Text style={styles.label}>New Password: (leave blank to keep current password)</Text>
+                    <Text style={styles.label}>New Password:</Text>
+                    <Text style={styles.helperText}>Leave blank to keep current password!</Text>
                     <TextInput
                         placeholder="New Password"
                         value={user.password}
@@ -227,6 +237,30 @@ const styles = StyleSheet.create({
     squareButton: {alignItems: 'center', justifyContent: 'center'},
     header: {flexDirection: 'row', alignItems: 'center', marginBottom: 20,},
     headerText: {flex: 1, fontSize: 28, textAlign: 'center',},
+    emailContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        borderColor: 'black',
+        borderWidth: 1,
+        borderRadius: 10,
+        padding: 0,
+        marginBottom: 5,
+        height: 35,
+    },
+    emailInput: {
+        flex: 1,
+        color: 'black',
+        fontSize: 16,
+        borderRadius: 10,
+        borderBottomRightRadius: 0,
+        borderTopRightRadius: 0,
+        paddingLeft: 10,
+        height: '100%',
+        width: '90%',
+    },
+    emailDomain: {fontSize: 16, color: 'black', marginRight: 3,},
+    helperText: {fontSize: 12, color: '#b0b0b0', marginBottom: 15,},
+    verticalLine: {width: 2, height: '100%', backgroundColor: 'gray', marginHorizontal: 1,},
 });
 
 export default UserEditInfo;

--- a/Frontend/userInterface/screens/ViewReports.tsx
+++ b/Frontend/userInterface/screens/ViewReports.tsx
@@ -72,6 +72,7 @@ const ViewReports: React.FC = () => {
                             title={`Report Type: ${report.report_type}`}
                             description={`Reporter: ${report.reporter}\nContext: ${report.context}`}
                             buttonLabel={undefined} onPress={undefined}
+                            iconName="alert-circle"
                         />
                     ))}
                 </ScrollView>


### PR DESCRIPTION
Changes made:
- `SupervisorEditAccount` and `UserEditInfo` got the email formatting from the create account pages
- Autofill just the email prefix added to those pages as well
- Modified `Card` to require an icon (from IonIcons) and added them to the following:
  - `SupervisorHomePage`
  - `DriverHomePage`
  - `RiderHomePage`
  - `ViewReports`
  - `SupervisorEditUser`
- `SupervisorEditUser` user descriptions now show the full role instead of 'S', 'D', 'A', or 'R'